### PR TITLE
Misleading achievements

### DIFF
--- a/secronom/Modification_Files/secro_achievements.json
+++ b/secronom/Modification_Files/secro_achievements.json
@@ -514,41 +514,5 @@
     "hidden_by": [ "achievement_secronom_special_meat_eat" ],
     "description": "Dare to eat what you've sworn to destroy.\n",
     "requirements": [ { "event_statistic": "num_avatar_secronom_effget_secro_flesh_bio_limb", "is": ">=", "target": 1 } ]
-  },
-  {
-    "id": "achievement_secronom_special_survive1",
-    "type": "achievement",
-    "name": "<color_light_red>(Secronom)</color> 30th Day Survived",
-    "hidden_by": [ "achievement_secronom_special_survive1" ],
-    "description": "Warning: mutants have become more aggressive.\n",
-    "time_constraint": { "since": "game_start", "is": ">=", "target": "30 days" },
-    "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything" } ]
-  },
-  {
-    "id": "achievement_secronom_special_survive2",
-    "type": "achievement",
-    "name": "<color_light_red>(Secronom)</color> 6th Month Survived",
-    "hidden_by": [ "achievement_secronom_special_survive2" ],
-    "description": "Warning: mutants are much more dangerous.\n",
-    "time_constraint": { "since": "game_start", "is": ">=", "target": "180 days" },
-    "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything" } ]
-  },
-  {
-    "id": "achievement_secronom_special_survive3",
-    "type": "achievement",
-    "name": "<color_light_red>(Secronom)</color> 1 Year Survived",
-    "hidden_by": [ "achievement_secronom_special_survive3" ],
-    "description": "Warning: cataclysmic mutants will now rarely appear in the cities.\n",
-    "time_constraint": { "since": "game_start", "is": ">=", "target": "360 days" },
-    "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything" } ]
-  },
-  {
-    "id": "achievement_secronom_special_survive4",
-    "type": "achievement",
-    "name": "<color_light_red>(Secronom)</color> 2 Years Survived",
-    "hidden_by": [ "achievement_secronom_special_survive4" ],
-    "description": "Warning: this is the final frontier; cities are overrun by mutants.\n",
-    "time_constraint": { "since": "game_start", "is": ">=", "target": "720 days" },
-    "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything" } ]
   }
 ]

--- a/secronom/modinfo.json
+++ b/secronom/modinfo.json
@@ -5,7 +5,7 @@
     "name": "<color_light_red>Secronom</color>",
     "authors": [ "Axema Vales" ],
     "description": "\n<color_red>Brings your Cataclysm experience into a hellish nightmare\u2026</color>\n<color_dark_gray>◆ Not recommended for newbs ◆</color>\n\n<color_light_cyan>Note that this mod is currently in <color_light_green>stable</color> state. Bugs rarely appears, but if you encounter one or a recent CDDA update has caused an error, feel free to notify the maintainer by creating an issue on its GitHub repository or by sending a DM on Discord.</color>\n\n<color_light_gray>For changelogs, see <color_yellow>README.txt</color>.",
-    "version": "<color_light_green>V1.9 - 11/10/2020</color>",
+    "version": "<color_light_green>V1.9 - 12/26/2020</color>",
     "category": "content",
     "dependencies": [ "dda" ]
   }


### PR DESCRIPTION
Removed the survival achievements. These says warnings about the secronom zeds' evolution, but they're not accurate most of the time as some players adjust the evolution speed.