### PR TITLE
[Experimental] Update secro_mutation.json

### DIFF
--- a/secronom_lore_expansion/Modification Files/Others/secro_mutation.json
+++ b/secronom_lore_expansion/Modification Files/Others/secro_mutation.json
@@ -913,7 +913,7 @@
     "dodge_modifier": -6,
     "movecost_modifier": 1.15,
     "movecost_obstacle_modifier": 1.25,
-    "speed_modifier": 1.1,
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SPEED", "multiply": 0.1 } ] } ],
     "attackcost_modifier": 1.1,
     "attacks": [
       {


### PR DESCRIPTION
Since the change made on https://github.com/CleverRaven/Cataclysm-DDA/pull/47963 the speed modifiers on mutations are now consolidated under the "enchantments" field, the old "speed_modifier" field is no longer acknowledged.

This fixes the "invalid field" error