### PR TITLE
Adding "covers" values to armor that don't have it

### DIFF
--- a/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_flesh_addons.json
+++ b/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_flesh_addons.json
@@ -14,7 +14,7 @@
     "color": "white",
     "flags": [ "PERSONAL", "TRADER_KEEP", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 0, "coverage": 0 } ]
+    "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "torso" ] } ]
   },
   {
     "id": "secro_power_armor_flesh_bor",
@@ -51,6 +51,6 @@
     "flags": [ "PERSONAL", "TRADER_KEEP", "SEMITANGIBLE", "OVERSIZE", "ONLY_ONE", "TRADER_AVOID", "NO_TAKEOFF" ],
     "material_thickness": 1,
     "qualities": [ [ "SECRO_FLESH_WEAVING", 1 ], [ "SECRO_FLESH_RECONSTRUCTION", 1 ] ],
-    "armor": [ { "encumbrance": 0, "coverage": 0 } ]
+    "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "hand_l", "hand_r" ] } ]
   }
 ]

--- a/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_modules.json
+++ b/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_modules.json
@@ -39,7 +39,7 @@
     ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "POWERARMOR_COMPATIBLE", "NO_UNLOAD" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "torso" ] } ]
   },
   {
     "id": "secro_power_armor_module_core_act",
@@ -88,7 +88,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "torso", "head" ] } ]
   },
   {
     "id": "secro_power_armor_module_vessel_act",
@@ -131,7 +131,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "torso", "head" ] } ]
   },
   {
     "id": "secro_power_armor_module_electric",
@@ -162,7 +162,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10 }, "covers": [ "hand_l", "hand_r" ] ]
   },
   {
     "id": "secro_power_armor_module_electric_act",
@@ -218,7 +218,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
     "id": "secro_power_armor_module_pulsar",
@@ -249,7 +249,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "arm_l", "arm_r" ] } ]
   },
   {
     "id": "secro_power_armor_module_pulsar_act",
@@ -298,7 +298,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "arm_l", "arm_r" ] } ]
   },
   {
     "id": "secro_power_armor_module_optics",
@@ -329,7 +329,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "eyes" ] } ]
   },
   {
     "id": "secro_power_armor_module_optics_act",
@@ -370,6 +370,6 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "NO_UNLOAD", "NO_TAKEOFF", "RECHARGE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 } ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "eyes" ] } ]
   }
 ]

--- a/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_modules.json
+++ b/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armor_modules.json
@@ -162,7 +162,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ],
     "flags": [ "WATERPROOF", "OUTER", "STURDY", "ELECTRIC_IMMUNE", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 10 }, "covers": [ "hand_l", "hand_r" ] ]
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
     "id": "secro_power_armor_module_electric_act",

--- a/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armors.json
+++ b/secronom_lore_expansion/Modification Files/Items/Armors/secro_power_armors.json
@@ -392,6 +392,6 @@
     "use_action": { "type": "cast_spell", "spell_id": "secro_power_armor_feed", "no_fail": true, "need_worn": true, "level": 0 },
     "flags": [ "NO_TAKEOFF", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 0, "coverage": 0 } ]
+    "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "head", "eyes", "mouth" ] } ]
   }
 ]


### PR DESCRIPTION
Values are based on descriptions.
Need some double-check by someone who knows about balancing this mod. For example optics covers eyes but I don't know if "encumbrance 10" needed there.